### PR TITLE
Removed delegate registration for each pool

### DIFF
--- a/src/SharedInternPool.MemoryManagment.cs
+++ b/src/SharedInternPool.MemoryManagment.cs
@@ -41,21 +41,6 @@ namespace Ben.Collections.Specialized
 
         internal long Collections => _cleaner?.Collections ?? 0;
 
-        /// <summary>
-        /// This is the static function that is called from the gen2 GC callback.
-        /// The input object is the instance we want the callback on.
-        /// </summary>
-        /// <remarks>
-        /// The reason that we make this function static and take the instance as a parameter is that
-        /// we would otherwise root the instance to the Gen2GcCallback object, leaking the instance even when
-        /// the application no longer needs it.
-        /// </remarks>
-        private static bool Gen2GcCallbackFunc(object target)
-        {
-            // Enqueue trim to ThreadPool
-            return ((SharedInternPool)target).EnqueueTrim();
-        }
-
         private InternPoolCleaner? _cleaner;
         private bool EnqueueTrim()
         {

--- a/src/SharedInternPool.cs
+++ b/src/SharedInternPool.cs
@@ -279,7 +279,7 @@ namespace Ben.Collections.Specialized
 
             if (Interlocked.Exchange(ref _callbackCreated, 1) != 1)
             {
-                Gen2GcCallback.Register(Gen2GcCallbackFunc, this);
+                Gen2GcCallback.Register(self => ((SharedInternPool)self).EnqueueTrim(), this);
             }
 
             return pool;


### PR DESCRIPTION
The compiler only caches delegates only if they point to non capturing lambdas, but not pointing to static methods. The feature existed during about .NET 4.5 timeline, but lately was removed. Right now there's an ongoing discussion about bringing it back since it's very handy to reference static methods in LINQ method calls.

A tiny bonus: static modifier doesn't make a lambda method static, it just tells the compiler to prohibit any captures like in case of a static method. Delegates in CLR historically were optimized for instance methods since .NET is object oriented and therefore most invocations involves a target. Therefore, using a static lambda gives boost not only by caching, but also due to delegate internals.
