### PR TITLE
Fixed potential torn reads on 32-bit

### DIFF
--- a/src/InternPoolEventSource.cs
+++ b/src/InternPoolEventSource.cs
@@ -10,7 +10,7 @@ namespace Ben.Collections.Specialized
 {
     internal sealed class InternPoolEventSource : EventSource
     {
-        public static readonly InternPoolEventSource Log = new();
+        public static readonly InternPoolEventSource Log = new InternPoolEventSource();
 
         private SharedInternPool? _pool;
 
@@ -48,7 +48,7 @@ namespace Ben.Collections.Specialized
             {
                 if (lastUpdate == Interlocked.CompareExchange(ref _lastUpdate, newCheck, lastUpdate))
                 {
-                    Debug.Assert(_pool is not null, "EventSource should be enabled");
+                    Debug.Assert(_pool != null, "EventSource should be enabled");
                     _stats = _pool.Stats;
                 }
             }

--- a/src/SharedInternPool.Metrics.cs
+++ b/src/SharedInternPool.Metrics.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Ben Adams. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
+
 namespace Ben.Collections.Specialized
 {
     public partial class SharedInternPool
@@ -14,10 +16,10 @@ namespace Ben.Collections.Specialized
         {
             get
             {
-                long totalAdded = _totalAdded;
-                long totalConsidered = _totalConsidered;
-                long totalDeduped = _totalDeduped;
-                long totalEvicted = _totalEvictedCount;
+                long totalAdded = Volatile.Read(ref _totalAdded);
+                long totalConsidered = Volatile.Read(ref _totalConsidered);
+                long totalDeduped = Volatile.Read(ref _totalDeduped);
+                long totalEvicted = Volatile.Read(ref _totalEvictedCount);
                 int totalCount = 0;
                 foreach (InternPool? pool in _pools)
                 {
@@ -42,7 +44,7 @@ namespace Ben.Collections.Specialized
         {
             get
             {
-                long total = _totalAdded;
+                long total = Volatile.Read(ref _totalAdded);
                 foreach (InternPool? pool in _pools)
                 {
                     if (pool != null)
@@ -62,7 +64,7 @@ namespace Ben.Collections.Specialized
         {
             get
             {
-                long total = _totalConsidered;
+                long total = Volatile.Read(ref _totalConsidered);
                 foreach (InternPool? pool in _pools)
                 {
                     if (pool != null)
@@ -102,7 +104,7 @@ namespace Ben.Collections.Specialized
         {
             get
             {
-                long total = _totalDeduped;
+                long total = Volatile.Read(ref _totalDeduped);
                 foreach (InternPool? pool in _pools)
                 {
                     if (pool != null)
@@ -122,7 +124,7 @@ namespace Ben.Collections.Specialized
         {
             get
             {
-                long total = _totalEvictedCount;
+                long total = Volatile.Read(ref _totalEvictedCount);
                 foreach (InternPool? pool in _pools)
                 {
                     if (pool != null)


### PR DESCRIPTION
I read anywhere that this code isn't threadsafe (which is OK), but the event counters are read from a different thread, so for correctness there shouldn't be torn reads (on 32-bit systems).